### PR TITLE
Fixed issue with unicode titles in Vzaar Java SDK

### DIFF
--- a/src/main/java/com/vzaar/client/RestClient.java
+++ b/src/main/java/com/vzaar/client/RestClient.java
@@ -20,6 +20,7 @@ import org.apache.http.client.methods.HttpPatch;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.ContentBody;
@@ -191,7 +192,7 @@ public class RestClient {
     }
 
     private <T extends HttpEntityEnclosingRequest> T setPayload(T request, Object payload) throws JsonProcessingException, UnsupportedEncodingException {
-        StringEntity entity = new StringEntity(objectMapper.writeValueAsString(payload));
+        StringEntity entity = new StringEntity(objectMapper.writeValueAsString(payload), "UTF-8");
         entity.setContentType("application/json");
         request.setEntity(entity);
         return request;


### PR DESCRIPTION
Unicode titles were not working under the Java SDK (server would reply 500 Internal Server error) when using non-standard characters such as the ones in "Decoração Björn Białystok Niño Bacalhau à Brá". Tracked it down to the StringEntity forcing everything to use "ISO-8859-1" by default.

I've change it to UTF-8 and everything works now. The browser playground, as far as I could tell, is also using UTF-8/Unicode (or rather, not specifying it and letting the target Vzaar backend service detect it) since I could use the above example from the WebUI but not from the JDK SDK.

I couldn't run any of the tests since I noticed a lot of the style-checks were failing already..